### PR TITLE
feat: add types for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+export const Api: typeof import("./lib/Api.js");
+export const User: typeof import("./lib/User.js");
+export const Record: typeof import("./lib/Record.js");
+export const News: typeof import("./lib/News.js");

--- a/lib/Api.d.ts
+++ b/lib/Api.d.ts
@@ -1,0 +1,97 @@
+export = Api;
+declare class Api {
+    /**
+     * Creates a new tetrio-node object
+     * @param {String} token your tetrio user token
+     * @param {Boolean} [options.notFoundAsError=true] Throw an error on not found instead of returning nothing
+     */
+    constructor(token: string, options?: {});
+    token: string;
+    baseUrl: string;
+    notFoundAsError: boolean;
+    get config(): {
+        notFoundAsError: boolean;
+    };
+    get header(): {
+        headers: {
+            Authorization: string;
+        };
+    };
+    apiCall(endpoint: any): Promise<any>;
+    /**
+     * Returns a not found error or the response, depending on the config
+     * @param {Object} response
+     * @returns {Object}
+     */
+    notFound(response: any): any;
+    /**
+     * Returns an User object
+     * @param {Object} options
+     * @param {String} options.user Specify an user to return data from
+     * @param {"username"|"id"} [options.type] Specify if `uuser` is a userId or a username
+     * @returns {Promise<User{}>}
+     */
+    getUser(options: {
+        user: string;
+        type: "username" | "id";
+    }): Promise<User>;
+    /**
+     * Return an userId
+     * @param {String} username
+     */
+    getUserId(username: string): Promise<any>;
+    /**
+     * Returns 10 Record in Array
+     * @param {Object} options
+     * @param {String} options.user Specify an user to return data from
+     * @param {"username"|"id"} [options.type] Specify if `user` is a userId or a username
+     * @param {"40l"|"blitz"} [options.gameType]
+     * @returns {Promise<User{}>}
+     */
+    getTopScores(options: {
+        user: string;
+        type: "username" | "id";
+        gameType: "40l" | "blitz";
+    }): Promise<User>;
+    /**
+     * @param {Object} options
+     * @param {String} options.replayId
+     */
+    getReplayShort(options: {
+        replayId: string;
+    }): Promise<any>;
+    /**
+     * Returns 10 Record in Array
+     * @param {Object} options
+     * @param {String} options.user Specify an user to return data from
+     * @param {"username"|"id"} [options.type] Specify if `user` is a userId or a username
+     * @returns {Promise<User{}>}
+     */
+    getRecentScores(options: {
+        user: string;
+        type: "username" | "id";
+    }): Promise<User>;
+    /**
+     * Returns 10 Record in Array
+     * @param {Object} options
+     * @param {"40l"|"blitz"} [options.gameType]
+     * @returns {Promise<User{}>}
+     */
+    getGlobalLeaderboard(options: {
+        gameType: "40l" | "blitz";
+    }): Promise<User>;
+    /**
+     * Returns 10 Record in Array
+     * @param {Object} options
+     * @param {"xp"|"league"} [options.by]
+     * @returns {Promise<User{}>}
+     */
+    getGlobalUsers(options: {
+        by: "xp" | "league";
+    }): Promise<User>;
+    /**
+     * Return News
+     */
+    getNews(): Promise<any>;
+}
+import User = require("./User.js");

--- a/lib/News.d.ts
+++ b/lib/News.d.ts
@@ -1,0 +1,26 @@
+export = News;
+/**
+ * A news
+ * @prop {String} id
+ * @prop {String} type
+ * @prop {Object} data
+ * @prop {String} data.username
+ * @prop {String} data.gameType
+ * @prop {String} data.rank
+ * @prop {String} data.result
+ * @prop {String} data.replayId
+ * @prop {Date} date
+ */
+declare class News {
+    constructor(data: any);
+    id: any;
+    type: any;
+    data: {
+        username: any;
+        gameType: any;
+        rank: any;
+        result: any;
+        replayId: any;
+    };
+    date: any;
+}

--- a/lib/Record.d.ts
+++ b/lib/Record.d.ts
@@ -1,0 +1,70 @@
+export = Record;
+/**
+ * A record.
+ * @prop {String} id
+ * @prop {Object} user
+ * @prop {String} user.username
+ * @prop {String} user.id
+ * @prop {String} stream
+ * @prop {String} replayId
+ * @prop {String} date
+ * @prop {Object} endcontext
+ * @prop {Number} endcontext.seed
+ * @prop {Number} endcontext.lines
+ * @prop {Number} endcontext.inputs
+ * @prop {Number} endcontext.topCombo
+ * @prop {Number} endcontext.topBtb
+ * @prop {Number} endcontext.tspins
+ * @prop {Number} endcontext.piecesPlaced
+ * @prop {Object} endcontext.clears
+ * @prop {Number} endcontext.clears.singles
+ * @prop {Number} endcontext.clears.doubles
+ * @prop {Number} endcontext.clears.triples
+ * @prop {Number} endcontext.clears.quads
+ * @prop {Number} endcontext.clears.tspinsSingles
+ * @prop {Number} endcontext.clears.tspinsDoubles
+ * @prop {Number} endcontext.clears.tspinsTriples
+ * @prop {Number} endcontext.clears.allClear
+ * @prop {Object} endcontext.finesse
+ * @prop {Number} endcontext.finesse.faults
+ * @prop {Number} endcontext.finesse.perfectPieces
+ * @prop {Number} endcontext.finesse.percentage
+ * @prop {Number} score
+ * @prop {Number} finalTime
+ * @prop {String} gameType
+ * @prop {Number} rank
+ */
+declare class Record {
+    constructor(data: any);
+    id: any;
+    user: {
+        username: any;
+        id: any;
+    };
+    stream: any;
+    replayId: any;
+    date: any;
+    gameType: any;
+    score: any;
+    finalTime: any;
+    endcontext: {
+        seed: any;
+        lines: any;
+        inputs: any;
+        level: any;
+        topCombo: any;
+        topBtb: any;
+        tspins: any;
+        piecesPlaced: any;
+        clears: {
+            singles: any;
+            doubles: any;
+            triples: any;
+            quads: any;
+            tspinSingles: any;
+            tspinDoubles: any;
+            tspinTriples: any;
+            allClear: any;
+        };
+    };
+}

--- a/lib/User.d.ts
+++ b/lib/User.d.ts
@@ -1,0 +1,66 @@
+export = User;
+/**
+ * A user.
+ * @prop {String} id
+ * @prop {String} username
+ * @prop {String} role
+ * @prop {Array} badges
+ * @prop {Number} exp
+ * @prop {Number} gamesPlayed
+ * @prop {Number} gamesWon
+ * @prop {Number} secondsPlayed
+ * @prop {String} country
+ * @prop {Boolean} isSupporter
+ * @prop {Boolean} isVerified
+ * @prop {Object} records
+ * @prop {Record} records.sprint
+ * @prop {Number} records.sprintRank
+ * @prop {Record} records.blitz
+ * @prop {Number} records.blitzRank
+ * @prop {Object} tetraLeague
+ * @prop {Number} tetraLeague.gamesPlayed
+ * @prop {Number} tetraLeague.gamesWon
+ * @prop {Number} tetraLeague.rating
+ * @prop {Number} tetraLeague.glicko
+ * @prop {Number} tetraLeague.rd
+ * @prop {String} tetraLeague.rank
+ * @prop {Number} tetraLeague.apm
+ * @prop {Number} tetraLeague.pps
+ * @prop {Number} tetraLeague.vs
+ * @prop {Number} tetraLeague.standing
+ * @prop {String} joinDate
+ */
+declare class User {
+    constructor(data: any);
+    id: any;
+    username: any;
+    role: any;
+    badges: any;
+    exp: any;
+    gamesPlayed: any;
+    gamesWon: any;
+    secondsPlayed: any;
+    country: any;
+    isVerified: any;
+    isSupporter: any;
+    records: {
+        sprint: Record;
+        sprintRank: any;
+        blitz: Record;
+        blitzRank: any;
+    };
+    tetraLeague: {
+        gamesPlayed: any;
+        gamesWon: any;
+        rating: any;
+        glicko: any;
+        rd: any;
+        rank: any;
+        apm: any;
+        pps: any;
+        vs: any;
+        standing: any;
+    };
+    joinDate: any;
+}
+import Record = require("./Record.js");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  // Change this to match your project
+  "include": [
+    "index.js"
+  ],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+  },
+}


### PR DESCRIPTION
This PR should allow for users to use typescript and have type support. The only thing you need to do is run `tsc` in the root directory whenever you change the JSDoc comments.